### PR TITLE
Adds concurrent garbage collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,21 @@ SRCS_MAP	= map.c
 
 SRCS_RC		= raycasting.c
 
+SRCS_GC		=  gc_handler.c \
+		   add_del.c \
+		   gc_routine.c 
+
 PATH_M		= srcs/
 PATH_PS		= srcs/parser/
 PATH_MAP	= srcs/map/
 PATH_RC		= srcs/raycasting/
+PATH_GC		= srcs/garbage_collector/
 
 SRCS		= $(addprefix $(PATH_M), $(SRCS_M)) \
 		  $(addprefix $(PATH_PS), $(SRCS_PS)) \
 		  $(addprefix $(PATH_MAP), $(SRCS_MAP)) \
-		  $(addprefix $(PATH_RC), $(SRCS_RC))
+		  $(addprefix $(PATH_RC), $(SRCS_RC)) \
+		  $(addprefix $(PATH_GC), $(SRCS_GC))
 
 HEADERS		= cub3d.h
 

--- a/includes/garbage_collector.h
+++ b/includes/garbage_collector.h
@@ -1,0 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   garbage_collector.h                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/24 13:29:50 by marvin            #+#    #+#             */
+/*   Updated: 2024/08/24 17:25:59 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef GARBAGE_COLLECTOR_H
+# define GARBAGE_COLLECTOR_H
+# include <pthread.h>
+# include <stdlib.h>
+# include <unistd.h>
+# include <string.h>
+# define MAX_GARBAGE 100
+# define STOP 0
+# define RUN 1
+# define SECOND 1000000
+
+typedef enum e_type
+{
+	NULL_TYPE,
+	POINTER,
+	ARRAY,
+	IMAGE,
+	WINDOW,
+	MLX,
+}	t_type;
+
+typedef struct s_gc_container
+{
+	void			*garbage[MAX_GARBAGE];
+	t_type			garbage_type[MAX_GARBAGE];
+	size_t			garbage_size[MAX_GARBAGE];
+	size_t			last_pos;
+	int				run_status;
+	pthread_mutex_t	garbage_lock;
+}	t_gc_container;
+
+int		gc_init(t_gc_container *gc, pthread_t *gc_thread);
+void	gc_destroy(t_gc_container *gc, pthread_t *gc_thread);
+int		add_del(void *ptr, t_type type, size_t size, t_gc_container *container);
+void	*gc_routine(void *arg);
+#endif 

--- a/srcs/garbage_collector/add_del.c
+++ b/srcs/garbage_collector/add_del.c
@@ -1,0 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   garbage_collector.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/24 13:29:45 by marvin            #+#    #+#             */
+/*   Updated: 2024/08/24 13:29:45 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "garbage_collector.h"
+
+static int	wait_for_free_slot(t_gc_container *container)
+{
+	size_t	cycles;
+
+	cycles = 0;
+	while (cycles < 15)
+	{
+		usleep(1 * SECOND);
+		pthread_mutex_lock(&container->garbage_lock);
+		if (container->last_pos != MAX_GARBAGE - 1)
+		{
+			pthread_mutex_unlock(&container->garbage_lock);
+			return (0);
+		}
+		else
+		{
+			cycles++;
+			pthread_mutex_unlock(&container->garbage_lock);
+		}
+	}
+	write(STDERR_FILENO, "Error: GC: Wait for free slot timeout\n", 39);
+	return (1);
+}
+
+int	add_del(void *ptr, t_type type, size_t size, t_gc_container *container)
+{
+	size_t	insert_pos;
+
+	pthread_mutex_lock(&container->garbage_lock);
+	insert_pos = container->last_pos;
+	if (insert_pos == MAX_GARBAGE - 1)
+	{
+		pthread_mutex_unlock(&container->garbage_lock);
+		if (wait_for_free_slot(container) == 0)
+			return (1);
+		pthread_mutex_lock(&container->garbage_lock);
+		insert_pos = container->last_pos;
+	}
+	container->garbage[insert_pos] = ptr;
+	container->garbage_type[insert_pos] = type;
+	container->garbage_size[insert_pos] = size;
+	container->last_pos++;
+	pthread_mutex_unlock(&container->garbage_lock);
+	return (0);
+}

--- a/srcs/garbage_collector/gc_handler.c
+++ b/srcs/garbage_collector/gc_handler.c
@@ -14,9 +14,9 @@
 
 int	gc_init(t_gc_container *gc, pthread_t *gc_thread)
 {
-	memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
-	memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
-	memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
+	ft_memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
+	ft_memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
+	ft_memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
 	gc->last_pos = 0;
 	gc->run_status = RUN;
 	if (pthread_mutex_init(&gc->garbage_lock, NULL) != 0)
@@ -37,7 +37,7 @@ void	gc_destroy(t_gc_container *gc, pthread_t *gc_thread)
 	pthread_join(*gc_thread, NULL);
 	gc_thread = NULL;
 	pthread_mutex_destroy(&gc->garbage_lock);
-	memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
-	memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
-	memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
+	ft_memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
+	ft_memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
+	ft_memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
 }

--- a/srcs/garbage_collector/gc_handler.c
+++ b/srcs/garbage_collector/gc_handler.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main_test.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/24 17:23:22 by marvin            #+#    #+#             */
+/*   Updated: 2024/08/24 17:23:22 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "garbage_collector.h"
+
+int	gc_init(t_gc_container *gc, pthread_t *gc_thread)
+{
+	memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
+	memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
+	memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
+	gc->last_pos = 0;
+	gc->run_status = RUN;
+	if (pthread_mutex_init(&gc->garbage_lock, NULL) != 0)
+		return (1);
+	if (pthread_create(gc_thread, NULL, gc_routine, gc) != 0)
+	{
+		pthread_mutex_destroy(&gc->garbage_lock);
+		return (1);
+	}
+	return (0);
+}
+
+void	gc_destroy(t_gc_container *gc, pthread_t *gc_thread)
+{
+	pthread_mutex_lock(&gc->garbage_lock);
+	gc->run_status = STOP;
+	pthread_mutex_unlock(&gc->garbage_lock);
+	pthread_join(*gc_thread, NULL);
+	gc_thread = NULL;
+	pthread_mutex_destroy(&gc->garbage_lock);
+	memset(gc->garbage, 0, MAX_GARBAGE * sizeof(void *));
+	memset(gc->garbage_type, 0, MAX_GARBAGE * sizeof(t_type));
+	memset(gc->garbage_size, 0, MAX_GARBAGE * sizeof(size_t));
+}

--- a/srcs/garbage_collector/gc_routine.c
+++ b/srcs/garbage_collector/gc_routine.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   del.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/24 15:18:38 by marvin            #+#    #+#             */
+/*   Updated: 2024/08/24 15:18:38 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "garbage_collector.h"
+
+static void	free_array(void **ptr, size_t size)
+{
+	size_t	index;
+
+	index = 0;
+	while (index < size)
+	{
+		free(ptr[index]);
+		index++;
+	}
+	free(ptr);
+}
+
+static void	del(void *ptr, size_t size, t_type type)
+{
+	if (type == POINTER)
+		free(ptr);
+	else if (type == ARRAY)
+		free_array((void **)ptr, size);
+}
+
+static void	sweep(t_gc_container *container)
+{
+	void	*ptr;
+	size_t	size;
+	size_t	position;
+	t_type	type;
+
+	position = container->last_pos;
+	if (position == 0)
+		return ;
+	while (container->last_pos > 0)
+	{
+		position = container->last_pos - 1;
+		ptr = container->garbage[position];
+		size = container->garbage_size[position];
+		type = container->garbage_type[position];
+		del(ptr, size, type);
+		container->garbage[position] = NULL;
+		container->garbage_size[position] = 0;
+		container->garbage_type[position] = NULL_TYPE;
+		container->last_pos--;
+	}
+}
+
+void	*gc_routine(void *arg)
+{
+	t_gc_container	*container;
+
+	container = (t_gc_container *)arg;
+	while (1)
+	{
+		pthread_mutex_lock(&container->garbage_lock);
+		sweep(container);
+		if (container->run_status == STOP)
+		{
+			pthread_mutex_unlock(&container->garbage_lock);
+			break ;
+		}
+		pthread_mutex_unlock(&container->garbage_lock);
+		usleep(5 * SECOND);
+	}
+	return (NULL);
+}


### PR DESCRIPTION
Adds a garbage collector module that runs in a concurrent thread to the main process. In case we feel like experimenting with more advanced forms of garbage collection. It has 3 functions and one routine logic for the thread it creates.

gc_init() and gc_destroy() act respectively as initalizers and destroyers for the ressources the gc (garbage collector) handlers.
add_del() is called by the main process to add to the garbage collection queue when a pointer needs to be freed.

The gc works by manipulating arrays insides a t_gc_container struct, defined in the .h file, to periodically call free() on pointers that the main process wrote there over the course of runtime.

the container has three arrays, a mutex to prevent race conditions, a last_pos var to retrieve the current state of the queue and properly iterate through it, and an int flag used to signal when to break out of the routine loop and return. 
The max size of the gc has been arbitrarily set to a 100 pointers, though we should be way below that for this project.

The gc currently **DOES NOT** handle dangling pointers. As such, we need to set a pointer to NULL after it has been added to the garbage queue via add_del().

### **gc_init()**
gc_init() takes two arguments, a pthread_t pointer and a t_gc_container pointer. 
It will initialize the t_gc_container and create the thread usingf the pthread_t pointer, passing the container to it as well as giving it the gc_routine() job.
the function will return 0 upon initialization success, or 1 in case of error.

### **gc_destroy()**
gc_destroy() takes two arguments, the pthread_t pointer corresponding to the gc thread, and its respective t_gc_container. It will destroy the mutex, call pthread_join() on the thread and set all of the values in the container back to 0/NULL.

### **add_del()**
add_del() takes four arguments:
ptr: pointer that needs to be freed.
type: the type of data from t_type of the pointer.
size: the number of elements within the  pointer if said pointer is an array.
container: the t_gc_container of the current running gc.

It will add to the garbage collector queue the pointer that must be freed.
It will return 0 upon success, or 1 in case of error.
Currently, the only error case corresponds to a timeout error if no free slots can be found within the garbage array of the gc container.
The only scenarios which could cause this are system errors concerning free(), the wrapper functions for free(), or the system cancelling the gc thread through SIGABRT for instance in case of critical bugs while the main process is still running. It should not happen.

The main process should be made to free and exit if add_del() returns an error, because it would mean that it has no garbage collection capabilities anymore.

### **sweep()**
sweep() is the main routine function of the gc thread, it takes the gc container as argument.
Every 5 seconds, the thread will call sweep(), checking the position variable for any change in its garbage queue. If position is different than 0, then the thread will call del() on each member of the garbage array, going from the last element to the first one.
del() is the function in which the thread will check for garbage_type and properly triage the pointer to the correct free() wrapper function, currently only free() (for simple pointers) and free_array() (for arrays) are implemented. The size variable will be used for complex elements like arrays so that the routine knows how many iterative free() calls need to be performed.

Once sweep() is done running, the thread will check for run_status to know whether or not it needs to go into another cycle. run_status is set to RUN in init_gc() and set to STOP in destroy_gc() right before the pthread_join() call in the main process.



