### PR TITLE
Parser find_start() improvement

### DIFF
--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 12:12:00 by tsuchen           #+#    #+#             */
-/*   Updated: 2024/08/26 15:48:20 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/08/27 13:17:50 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,8 @@ t_parse_status	verify_map(char **map, t_data *data)
 {
 	uint32_t	start[2];
 
-	start[0] = 0;
-	start[1] = 0;
+	start[0] = -1;
+	start[1] = -1;
 	if (check_invalid_chars(map) == MAP_ERR)
 		return (MAP_ERR);
 	fill_whitespaces(map);

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -52,8 +52,8 @@ t_parse_status	verify_map(char **map, t_data *data)
 {
 	uint32_t	start[2];
 
-	start[0] = -1;
-	start[1] = -1;
+	start[0] = 0;
+	start[1] = 0;
 	if (check_invalid_chars(map) == MAP_ERR)
 		return (MAP_ERR);
 	fill_whitespaces(map);

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/16 18:12:37 by jteissie          #+#    #+#             */
-/*   Updated: 2024/08/26 15:47:38 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/08/27 13:11:50 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,7 +92,7 @@ t_parse_status	find_start(uint32_t coordinates[], char **map)
 		y = 0;
 		x++;
 	}
-	if (coordinates[0] == 0 && (!is_cardinal_pos(map[0][0])))
+	if (coordinates[0] == 0 && coordinates[1] == 0)
 		return (MAP_ERR);
 	return (MAP_OK);
 }

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/16 18:12:37 by jteissie          #+#    #+#             */
-/*   Updated: 2024/08/27 13:11:50 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/08/27 13:18:34 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,7 @@ t_parse_status	find_start(uint32_t coordinates[], char **map)
 		{
 			if (is_cardinal_pos(map[x][y]))
 			{
-				if (coordinates[0] != 0 || coordinates[1] != 0)
+				if (coordinates[0] != -1 || coordinates[1] != -1)
 					return (MAP_ERR);
 				coordinates[0] = x;
 				coordinates[1] = y;
@@ -92,7 +92,7 @@ t_parse_status	find_start(uint32_t coordinates[], char **map)
 		y = 0;
 		x++;
 	}
-	if (coordinates[0] == 0 && coordinates[1] == 0)
+	if (coordinates[0] == -1)
 		return (MAP_ERR);
 	return (MAP_OK);
 }

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/16 18:12:37 by jteissie          #+#    #+#             */
-/*   Updated: 2024/08/27 13:18:34 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/08/27 13:23:59 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,7 @@ t_parse_status	find_start(uint32_t coordinates[], char **map)
 		{
 			if (is_cardinal_pos(map[x][y]))
 			{
-				if (coordinates[0] != -1 || coordinates[1] != -1)
+				if (coordinates[0] != 0 || coordinates[1] != 0)
 					return (MAP_ERR);
 				coordinates[0] = x;
 				coordinates[1] = y;
@@ -92,7 +92,7 @@ t_parse_status	find_start(uint32_t coordinates[], char **map)
 		y = 0;
 		x++;
 	}
-	if (coordinates[0] == -1)
+	if (coordinates[0] == 0 && coordinates[1] == 0)
 		return (MAP_ERR);
 	return (MAP_OK);
 }


### PR DESCRIPTION
Clarifies find_start()
- Removed unecessary is_cardinal_pos() negative check before return value of find_start() function in verify_map().

Closes:#8