### PR TITLE
Verify map exception leak fix

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cub3d.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsuchen <tsuchen@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 00:19:44 by tsuchen           #+#    #+#             */
-/*   Updated: 2024/09/04 12:28:56 by tsuchen          ###   ########.fr       */
+/*   Updated: 2024/09/04 13:18:12 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,6 +139,7 @@ typedef struct s_data
 }	t_data;
 
 int		cleanup(t_data *data);
+void	cleanup_textures(t_textdata *textures, void *mlx);
 int		game_init(t_data *data);
 int		key_events(int keycode, t_data *data);
 int		mouse_move(int x, int y, t_data *data);

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsuchen <tsuchen@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 15:00:57 by jteissie          #+#    #+#             */
-/*   Updated: 2024/09/03 16:25:54 by tsuchen          ###   ########.fr       */
+/*   Updated: 2024/09/04 13:29:24 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,11 +29,11 @@ typedef enum e_texture
 
 typedef struct s_textdata
 {
-	void		*text_img[5];
-	int			tex_h[5];
-	int			tex_w[5];
-	char		*text_paths[5];
-	char		*text_addr[5];
+	void		*text_img[TEXTURES_PATHS];
+	int			tex_h[TEXTURES_PATHS];
+	int			tex_w[TEXTURES_PATHS];
+	char		*text_paths[TEXTURES_PATHS];
+	char		*text_addr[TEXTURES_PATHS];
 	int			floor;
 	int			ceiling;
 	int			textures_nb;

--- a/maps/bad_maps/start_on_edge.cub
+++ b/maps/bad_maps/start_on_edge.cub
@@ -1,0 +1,17 @@
+NO ./assets/made_wall_n.xpm
+SO ./assets/made_wall_s.xpm
+WE ./assets/made_wall_w.xpm
+EA ./assets/made_wall_e.xpm
+D ./assets/made_door.xpm
+
+Fa 64,     64,      64
+C 182,182,182
+
+1111111
+1000001
+1000001
+100N001
+1000001
+1111111
+1101    000001
+111111110011111

--- a/maps/bad_maps/start_on_edge.cub
+++ b/maps/bad_maps/start_on_edge.cub
@@ -4,7 +4,7 @@ WE ./assets/made_wall_w.xpm
 EA ./assets/made_wall_e.xpm
 D ./assets/made_door.xpm
 
-Fa 64,     64,      64
+F 64,     64,      64
 C 182,182,182
 
 1111111

--- a/srcs/cleanup.c
+++ b/srcs/cleanup.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   cleanup.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsuchen <tsuchen@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 17:04:32 by jteissie          #+#    #+#             */
-/*   Updated: 2024/09/03 17:36:22 by tsuchen          ###   ########.fr       */
+/*   Updated: 2024/09/04 13:17:57 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-static void	cleanup_textures(t_textdata *textures, void *mlx)
+void	cleanup_textures(t_textdata *textures, void *mlx)
 {
 	if (textures->text_img[N])
 		mlx_destroy_image(mlx, textures->text_img[N]);

--- a/srcs/parser/get_textures_utils.c
+++ b/srcs/parser/get_textures_utils.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 17:29:47 by jteissie          #+#    #+#             */
-/*   Updated: 2024/08/29 14:00:13 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/09/04 13:29:06 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,7 +97,7 @@ void	panic_clean(t_textdata *textures)
 	size_t	i;
 
 	i = 0;
-	while (i < 4)
+	while (i < TEXTURES_PATHS)
 	{
 		if (textures->text_paths[i])
 			free(textures->text_paths[i]);

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 12:12:00 by tsuchen           #+#    #+#             */
-/*   Updated: 2024/09/02 14:37:40 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/09/04 13:18:57 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,10 +102,11 @@ int	parse_map(t_data *data)
 	data->map = build_map(data, line);
 	close(data->map_fd);
 	if (!data->map)
-		return (PANIC);
+		return (cleanup_textures(data->textures, data->mlx), PANIC);
 	if (verify_map(data->map, data) == MAP_ERR)
 	{
 		ft_putstr_fd("Error\n", STDERR_FILENO);
+		cleanup_textures(data->textures, data->mlx);
 		return (ft_free_all(data->map), PANIC);
 	}
 	return (SUCCESS);


### PR DESCRIPTION
Fixed leak from textdata by calling cleanup_textures in parse_map() when verify_map() would return PANIC.
Changed cleanup_textures() from static to globally accessible from parser.h.

Fixed leak from get_textures_info() caused by panic_clean() in get_textures_util() being hardcoded to iterate over 4 buffers of the textdata struct, missing one. Changed magic index numbers in textdata struct buffers in parser.h to use proper macro for readability.